### PR TITLE
feat(settings): add database wipe functionality with confirmation alert

### DIFF
--- a/src/app/(tabs)/settings.jsx
+++ b/src/app/(tabs)/settings.jsx
@@ -1,10 +1,33 @@
-import { Switch, Button, StyleSheet } from 'react-native';
-import { ThemedView } from '../../components/themed-view';
+import { Alert, Button, StyleSheet, Switch } from 'react-native';
 import { ThemedText } from '../../components/themed-text';
+import { ThemedView } from '../../components/themed-view';
 import { useSettings } from '../../context/SettingsContext.jsx';
+import { resetDatabase } from '../../db/db.js';
 
 export default function SettingsScreen() {
   const { theme, textSize, updateTheme, updateTextSize } = useSettings();
+
+  async function handleWipeDatabase() {
+    Alert.alert(
+      'Confirm Wipe',
+      'This will permanently delete all app data (roll history, skins, achievements, and settings). Do you want to continue?',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Wipe',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await resetDatabase();
+              Alert.alert('Success', 'Database wiped. App data will reinitialize on next use.');
+            } catch (error) {
+              Alert.alert('Error', error?.message ?? String(error));
+            }
+          },
+        },
+      ]
+    );
+  }
 
   return (
     <ThemedView style={styles.container}>
@@ -22,6 +45,15 @@ export default function SettingsScreen() {
         <ThemedText>Text Size: {textSize}</ThemedText>
         <Button title="Increase" onPress={() => updateTextSize(textSize + 1)} />
         <Button title="Decrease" onPress={() => updateTextSize(Math.max(10, textSize - 1))} />
+      </ThemedView>
+
+      <ThemedView style={styles.section}>
+        <ThemedText>Danger Zone</ThemedText>
+        <Button
+          title="Wipe Database"
+          color="#d9534f"
+          onPress={handleWipeDatabase}
+        />
       </ThemedView>
     </ThemedView>
   );

--- a/src/db/db.js
+++ b/src/db/db.js
@@ -18,8 +18,8 @@
  */
 
 import { Asset } from 'expo-asset';
-import { Platform } from 'react-native';
 import * as SQLite from 'expo-sqlite';
+import { Platform } from 'react-native';
 
 // Implemented modules
 export { getBetrayerTurnAfter } from './diceSets.js';
@@ -43,14 +43,52 @@ function removeSqlLineComments(sqlText) {
 
 function splitSqlStatements(sqlText) {
   const sqlWithoutComments = removeSqlLineComments(sqlText);
-  return sqlWithoutComments
-    .split(';')
-    .map(function (statement) {
-      return statement.trim();
-    })
-    .filter(function (statement) {
-      return statement.length > 0;
-    });
+
+  const lines = sqlWithoutComments.split('\n');
+  const statements = [];
+  let current = '';
+  let inTrigger = false;
+
+  for (let rawLine of lines) {
+    const line = rawLine + '\n';
+    const trimmedUpper = rawLine.trim().toUpperCase();
+
+    // Detect start of a trigger definition
+    if (!inTrigger && trimmedUpper.startsWith('CREATE TRIGGER')) {
+      inTrigger = true;
+    }
+
+    current += line;
+
+    if (inTrigger) {
+      // Detect end of trigger block (END or END;)
+      if (/^END\s*;?$/i.test(rawLine.trim())) {
+        statements.push(current.trim());
+        current = '';
+        inTrigger = false;
+      }
+      continue;
+    }
+
+    // When not in a trigger, split on semicolons at statement boundaries
+    if (rawLine.includes(';')) {
+      // A line may contain multiple statements; split them safely
+      const parts = current.split(';');
+      for (let i = 0; i < parts.length - 1; i++) {
+        const stmt = parts[i].trim();
+        if (stmt.length > 0) statements.push(stmt);
+      }
+      current = parts[parts.length - 1];
+    }
+  }
+
+  if (current.trim().length > 0) {
+    statements.push(current.trim());
+  }
+
+  return statements.filter(function (s) {
+    return s.length > 0;
+  });
 }
 
 async function ensureSchemaInitialized(database) {
@@ -160,15 +198,45 @@ export async function getDB() {
  */
 export async function resetDatabase() {
   const database = await getDB();
-  await database.execAsync(`
-    DROP TABLE IF EXISTS roll_history;
-    DROP TABLE IF EXISTS achievements;
-    DROP TABLE IF EXISTS skins;
-    DROP TABLE IF EXISTS dice_sets;
-    DROP TABLE IF EXISTS user_state;
-  `);
+
+  // Disable foreign key enforcement so we can drop tables in any order
+  try {
+    await database.execAsync('PRAGMA foreign_keys = OFF;');
+  } catch (err) {
+    console.warn('Failed to disable foreign_keys pragma:', err?.message ?? String(err));
+  }
+
+  try {
+    await database.execAsync(`
+      DROP TRIGGER IF EXISTS after_roll_insert;
+      DROP TRIGGER IF EXISTS initialize_betrayer_turn_after;
+
+      DROP TABLE IF EXISTS roll_history;
+      DROP TABLE IF EXISTS achievements;
+      DROP TABLE IF EXISTS skins;
+      DROP TABLE IF EXISTS dice_sets;
+      DROP TABLE IF EXISTS user_state;
+
+      -- Reset sqlite_sequence so AUTOINCREMENT values start over
+      DELETE FROM sqlite_sequence WHERE name IN ('skins','dice_sets','roll_history','achievements');
+    `);
+  } catch (err) {
+    console.warn('Error while dropping tables during resetDatabase:', err?.message ?? String(err));
+  } finally {
+    // Re-enable foreign key enforcement on this connection
+    try {
+      await database.execAsync('PRAGMA foreign_keys = ON;');
+    } catch (err) {
+      console.warn('Failed to re-enable foreign_keys pragma:', err?.message ?? String(err));
+    }
+  }
+
+  // Clear cached connection so getDB() will recreate and initialize schema
   db = null;
   dbPromise = null;
+
+  // Re-open and initialize immediately so the DB is reseeded right away
+  await getDB();
 }
 
 export function __resetDbForTests() {


### PR DESCRIPTION
This pull request adds a "Wipe Database" feature to the settings screen, allowing users to reset all app data via the UI. It also improves the database reset logic to handle triggers and foreign key constraints more robustly, and enhances the SQL statement splitting logic to correctly process trigger definitions.

**Settings UI and User Experience:**

* Added a "Danger Zone" section to the `SettingsScreen` with a "Wipe Database" button that prompts the user for confirmation before wiping all app data. [[1]](diffhunk://#diff-b5e830e608e0c9439851243f13037f36bc6adaa4580c59d354bad9c59f25e3c7L1-R31) [[2]](diffhunk://#diff-b5e830e608e0c9439851243f13037f36bc6adaa4580c59d354bad9c59f25e3c7R49-R57)

**Database Reset Functionality:**

* Enhanced the `resetDatabase` function in `db.js` to:
  * Disable foreign key checks before dropping tables to avoid constraint errors.
  * Drop relevant triggers in addition to tables.
  * Reset the `sqlite_sequence` table to restart AUTOINCREMENT values.
  * Re-enable foreign key checks after the operation.
  * Immediately re-initialize the database after wiping.

**SQL Parsing Improvements:**

* Improved the `splitSqlStatements` function to correctly handle SQL triggers, ensuring that multi-line trigger definitions are treated as single statements and not split incorrectly.

**Minor Code Cleanups:**

* Adjusted import order for consistency in `db.js`.